### PR TITLE
Small documentation/message fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ not be too cumborsome.
 
 The hosted service must have `github-app-user-auth` installed.
 
-1. Open a terminal, and type `github-app-user-auth`.
+1. Open a terminal, and type `github-app-user-auth` (you can also type `!github-app-user-auth` in a Jupyter Console or Notebook, which has the convenience of rendering the URL you'll need to access as a clickable link).
 
    If you're on a non-containerized system (like a HPC), you must
    also specify the path to put the credentials files in explicitly
@@ -126,7 +126,8 @@ The hosted service must have `github-app-user-auth` installed.
    `gitconfig` configuration mentioned earlier.
 
 2. It should give you a link to go to, and a code to input into the web
-   page when that link is opened. Open the link, enter the code there.
+   page when that link is opened. Open the link, enter the code there (the page accepts pasting, so you can copy it from the output).
+
 3. Grant access to the device in the web page, and you're done!
 
 Authentication is valid for **8 hours**, and once it expires, this

--- a/github_app_user_auth/auth.py
+++ b/github_app_user_auth/auth.py
@@ -22,8 +22,9 @@ def do_authenticate_device_flow(client_id):
     ).json()
 
     print(
-        f'Gos to {verification_resp["verification_uri"]} and enter the code {verification_resp["user_code"]}'
+        f'Go to {verification_resp["verification_uri"]} and enter the code: {verification_resp["user_code"]}'
     )
+    print('You have 15 minutes to enter this code (you can copy-paste it from above).')
     print('Waiting...', end='', flush=True)
 
     while True:
@@ -71,7 +72,7 @@ def main():
 
     access_token, expires_in = do_authenticate_device_flow(args.client_id)
     expires_in_hours = expires_in / 60 / 60
-    print(f"Authentication will expire in {expires_in_hours:0.1f} hours")
+    print(f"Success! Authentication will expire in {expires_in_hours:0.1f} hours.")
 
     # Create the file with appropriate permissions (0600) so other users can't read it
     with open(os.open(args.git_credentials_path, os.O_WRONLY | os.O_CREAT, 0o600), "w") as f:


### PR DESCRIPTION
Loving this, and I realized we can run it from the console/notebook even more conveniently than from the terminal :)

BTW - I'm thinking whether the entry point should be named something a little bit shorter/more convenient to type, say `ghauth` or `github-auth`  or similar? It's going to be a daily command, and the current name is a bit of a mouthful to type.

I also went through the GH docs looking for a way to automate things a bit further with a button, but the device flow seems to require explicitly visiting the login URL by hand, and it can't be iframed. The only thing I see to improve the flow would be to add a `%magic` version that runs the same cmd, but produces a nice HTML display in the console/notebook with a button that, upon click, both copies the code into the clipboard and opens the new URL. 

I'll play with that idea and will make a new PR if it works.