### PR TITLE
Add Jupyter support

### DIFF
--- a/github_app_user_auth/__main__.py
+++ b/github_app_user_auth/__main__.py
@@ -1,0 +1,3 @@
+from .auth import main
+
+main()

--- a/github_app_user_auth/auth.py
+++ b/github_app_user_auth/auth.py
@@ -85,7 +85,8 @@ def main(in_jupyter=False):
 
     access_token, expires_in = do_authenticate_device_flow(args.client_id, in_jupyter)
     expires_in_hours = expires_in / 60 / 60
-    success = f"Success! Authentication will expire in {expires_in_hours:0.1f} hours."
+    success = (f"Success! Authentication will expire in {expires_in_hours:0.1f} hours.\n<br>"
+               f"Process completed on: {time.asctime()}.")
     if in_jupyter:
         from IPython.display import display, HTML
         display(HTML(f'<p style="background-color:lightgreen;">{success}</p>'))

--- a/github_app_user_auth/auth.py
+++ b/github_app_user_auth/auth.py
@@ -77,7 +77,3 @@ def main():
     # Create the file with appropriate permissions (0600) so other users can't read it
     with open(os.open(args.git_credentials_path, os.O_WRONLY | os.O_CREAT, 0o600), "w") as f:
         f.write(f"https://x-access-token:{access_token}@github.com\n")
-
-
-if __name__ == "__main__":
-    main()

--- a/github_app_user_auth/auth.py
+++ b/github_app_user_auth/auth.py
@@ -85,7 +85,12 @@ def main(in_jupyter=False):
 
     access_token, expires_in = do_authenticate_device_flow(args.client_id, in_jupyter)
     expires_in_hours = expires_in / 60 / 60
-    print(f"Success! Authentication will expire in {expires_in_hours:0.1f} hours.")
+    success = f"Success! Authentication will expire in {expires_in_hours:0.1f} hours."
+    if in_jupyter:
+        from IPython.display import display, HTML
+        display(HTML(f'<p style="background-color:lightgreen;">{success}</p>'))
+    else:
+        print(success)
 
     # Create the file with appropriate permissions (0600) so other users can't read it
     with open(os.open(args.git_credentials_path, os.O_WRONLY | os.O_CREAT, 0o600), "w") as f:

--- a/github_app_user_auth/jupyter.py
+++ b/github_app_user_auth/jupyter.py
@@ -1,0 +1,4 @@
+if __name__ == '__main__':    
+    from .auth import main
+    
+    main(in_jupyter=True)


### PR DESCRIPTION
Once installed, then inside a Notebook or Console using the IPython kernel, one can type

```
%run -m github_app_user_auth.jupyter
```

resulting in:

![image](https://user-images.githubusercontent.com/57394/153109052-808f0191-cb35-47f3-bcf3-1b7852311454.png)

This doesn't modify the existing usage at the terminal, though it does add support for also calling the CLI entry point as `python -m github_app_user_auth` if desired.

This builds on the discussion from #7.